### PR TITLE
fix(setup): gracefully handle .env creation in make init-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include .env
+-include .env
 export
 
 .PHONY: init-hooks init-env up down build logs proto deps-frontend deps-backend deps-inference deps-training dev-frontend dev-backend dev-inference dev-training backend-local inference-local training-local frontend-local clean docs
@@ -19,7 +19,10 @@ init-hooks:
 	lefthook install
 
 init-env:
-	@if [ ! -f .env ]; then cp .env.example .env; echo "Error: .env file missing. Created template. Populate variables and rerun."; exit 1; fi
+#	@if [ ! -f .env ]; then cp .env.example .env; echo "Error: .env file missing. Created template. Populate variables and rerun."; exit 1; fi
+
+# New version (copies template and allows the program to continue):
+	@if [ ! -f .env ]; then cp .env.example .env; echo "Successfully created .env file from template. Please populate the variables!"; fi
 
 up: init-env
 	docker compose up -d

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,7 @@ init-hooks:
 	lefthook install
 
 init-env:
-#	@if [ ! -f .env ]; then cp .env.example .env; echo "Error: .env file missing. Created template. Populate variables and rerun."; exit 1; fi
-
-# New version (copies template and allows the program to continue):
+# copies template and allows the program to continue
 	@if [ ! -f .env ]; then cp .env.example .env; echo "Successfully created .env file from template. Please populate the variables!"; fi
 
 up: init-env


### PR DESCRIPTION
**Changes:**
1. Added `-include .env` at the top so `make` doesn't crash immediately when the file is missing.
2. Updated the `init-env` command. It now gracefully copies `.env.example` to `.env` without throwing an aggressive `exit 1` error, allowing the setup process to continue smoothly.