### PR TITLE
ci(lefthook): move linter invocations to docker

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -6,77 +6,77 @@ pre-commit:
       priority: 1
       root: "inference/"
       glob: "*.py"
-      run: poetry run black {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:latest_release black {staged_files}
       stage_fixed: true
     inference-flake8:
       priority: 2
       root: "inference/"
       glob: "*.py"
-      run: poetry run flake8 {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:latest {staged_files}
     inference-mypy:
       priority: 2
       root: "inference/"
       glob: "*.py"
-      run: poetry run mypy {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir cytopia/mypy:latest {staged_files}
 
     # Python: Training
     training-black:
       priority: 1
       root: "training/"
       glob: "*.py"
-      run: poetry run black {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:latest_release black {staged_files}
       stage_fixed: true
     training-flake8:
       priority: 2
       root: "training/"
       glob: "*.py"
-      run: poetry run flake8 {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:latest {staged_files}
     training-mypy:
       priority: 2
       root: "training/"
       glob: "*.py"
-      run: poetry run mypy {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir cytopia/mypy:latest {staged_files}
     training-test:
       priority: 3
       root: "training/"
       glob: "*.py"
-      run: poetry run pytest -v
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.11-slim bash -c "pip install -q pytest && pytest -v"
 
     # Go: Backend
     backend-goimports:
       priority: 1
       root: "backend/"
       glob: "*.go"
-      run: go run golang.org/x/tools/cmd/goimports@latest -w {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir cytopia/goimports:latest -w {staged_files}
       stage_fixed: true
     backend-golangci-lint:
       priority: 2
       root: "backend/"
       glob: "*.go"
-      run: go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run ./...
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir golangci/golangci-lint:latest golangci-lint run ./...
     backend-test:
       priority: 3
       root: "backend/"
       glob: "*.go"
-      run: go test -v ./...
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir golang:alpine go test -v ./...
 
     # TypeScript/React: Frontend
     frontend-prettier:
       priority: 1
       root: "frontend/"
       glob: "*.{ts,tsx,js,jsx,css,html}"
-      run: npx prettier --write {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir tmknom/prettier:latest --write {staged_files}
       stage_fixed: true
     frontend-eslint:
       priority: 2
       root: "frontend/"
       glob: "*.{ts,tsx,js,jsx}"
-      run: npx eslint {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir node:alpine npx --yes eslint {staged_files}
     frontend-tsc:
       priority: 2
       root: "frontend/"
       glob: "*.{ts,tsx}"
-      run: npx tsc --noEmit
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir node:alpine npx --yes typescript tsc --noEmit
 
     # MkDocs: Documentation
     docs-mkdocs:


### PR DESCRIPTION
### Description
This PR updates the `lefthook.yaml` configuration to run all pre-commit hooks (linters, formatters, and type checkers) entirely inside Docker containers, removing the need for local dependencies.

### Changes made
* Replaced local tool invocations (`poetry run`, `npx`, `go run`) with lightweight `docker run --rm -v` commands.
* Utilized official, minimal Docker images (e.g., `alpine` variants, `pyfound/black`) to ensure fast execution and minimize latency during `git commit`.
* Standardized the pre-commit environment across all tech stacks (Python, Go, TypeScript) to match the existing MkDocs approach.

**Closes #68**