### PR TITLE
Devops/68 lefthook docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,6 @@ logs:
 
 proto:
 	cd proto && buf generate
-	mkdir -p ../inference/src/inference/pb/ping/v1
-	touch ../inference/src/inference/pb/ping/__init__.py
-	touch ../inference/src/inference/pb/ping/v1/__init__.py
 
 deps-frontend: init-env
 	docker compose up -d postgres rabbitmq s3 inference backend

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ logs:
 
 proto:
 	cd proto && buf generate
+	mkdir -p ../inference/src/inference/pb/ping/v1
+	touch ../inference/src/inference/pb/ping/__init__.py
+	touch ../inference/src/inference/pb/ping/v1/__init__.py
 
 deps-frontend: init-env
 	docker compose up -d postgres rabbitmq s3 inference backend

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -65,7 +65,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to connect to gRPC server: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	app := &App{
 		logger:     log.New(os.Stdout, "", log.LstdFlags),

--- a/backend/internal/client/weather/client.go
+++ b/backend/internal/client/weather/client.go
@@ -122,7 +122,7 @@ func (c *OpenMeteoWeatherClient) doRequest(ctx context.Context, targetURL string
 	if err != nil {
 		return fmt.Errorf("executing request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected http status: %d", resp.StatusCode)

--- a/backend/internal/client/weather/client_test.go
+++ b/backend/internal/client/weather/client_test.go
@@ -49,7 +49,7 @@ func TestProcessDailyData(t *testing.T) {
 func setupMockServer(responseBody string, statusCode int) *httptest.Server {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(statusCode)
-		fmt.Fprint(w, responseBody)
+		_, _ = fmt.Fprint(w, responseBody)
 	})
 	return httptest.NewServer(handler)
 }
@@ -215,7 +215,7 @@ func TestFetchFutureWeather_ExpectedRequest(t *testing.T) {
 		// return anything with a valid structure so the client doesn't crash during parsing
 		dummyJSON := `{"daily": {"time": ["2023-10-28"], "temperature_2m_max": [22], "temperature_2m_min": [12], "precipitation_sum": [0]}}`
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, dummyJSON)
+		_, _ = fmt.Fprint(w, dummyJSON)
 	}))
 	defer server.Close()
 

--- a/backend/internal/handlers/excel_upload.go
+++ b/backend/internal/handlers/excel_upload.go
@@ -27,7 +27,7 @@ func UploadHandlerXLSX(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Błąd pobierania pliku", http.StatusBadRequest)
 		return
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	//tu juz mamy nasz plik file
 

--- a/backend/internal/parser/excel.go
+++ b/backend/internal/parser/excel.go
@@ -40,7 +40,7 @@ func (p *Parser) Parse(r io.Reader) (Raport, error) {
 	if err != nil {
 		return raport, fmt.Errorf("błąd otwierania pliku excel: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	sheetName := f.GetSheetName(f.GetActiveSheetIndex())
 	rows, err := f.GetRows(sheetName)

--- a/backend/internal/parser/test/parse_test.go
+++ b/backend/internal/parser/test/parse_test.go
@@ -14,7 +14,7 @@ func TestParseExcelToStruct(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Nie udało się otworzyć pliku testowego '%s': %v", filePath, err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	p := parser.NewParser()
 	raport, err := p.Parse(file)

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,5 +1,5 @@
 pre-commit:
-  piped: true
+  parallel: true
   commands:
     # Python: Inference
     inference-black:
@@ -17,7 +17,7 @@ pre-commit:
       priority: 2
       root: "inference/"
       glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q mypy && mypy --ignore-missing-imports --disable-error-code no-untyped-def {staged_files}"
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q poetry && poetry install && poetry run mypy {staged_files}"
 
     # Python: Training
     training-black:
@@ -35,12 +35,12 @@ pre-commit:
       priority: 2
       root: "training/"
       glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q mypy && mypy --ignore-missing-imports {staged_files}"
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q poetry && poetry install && poetry run mypy {staged_files}"
     training-test:
       priority: 3
       root: "training/"
       glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q poetry && poetry install --no-interaction --no-ansi --no-root -q && poetry run pytest -v"
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q poetry && poetry install && poetry run pytest -v"
 
     # Go: Backend
     backend-goimports:
@@ -53,7 +53,7 @@ pre-commit:
       priority: 2
       root: "backend/"
       glob: "*.go"
-      run: docker run --rm -v "$PWD:/app" -w /app golangci/golangci-lint:v2.12.2 bash -c "go mod download && golangci-lint run --disable errcheck ./..."
+      run: docker run --rm -v "$PWD:/app" -w /app golangci/golangci-lint:v2.12.2 bash -c "go mod download && golangci-lint run ./..."
     backend-test:
       priority: 3
       root: "backend/"

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,89 +1,79 @@
 pre-commit:
-  parallel: true
-  commands:
-    # Python: Inference
-    inference-black:
-      priority: 1
-      root: "inference/"
-      glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:24.4.2 black {staged_files}
-      stage_fixed: true
-    inference-flake8:
-      priority: 2
-      root: "inference/"
-      glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:7.0.0 {staged_files}
-    inference-mypy:
-      priority: 2
-      root: "inference/"
-      glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q poetry && poetry install && poetry run mypy {staged_files}"
+  piped: true
+  jobs:
+    # --- GROUP 1: FORMATTERS ---
+    - name: formatters
+      group:
+        parallel: true
+        jobs:
+          - name: inference-black
+            root: "inference/"
+            glob: "*.py"
+            run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:24.4.2 black {staged_files}
+            stage_fixed: true
+          - name: training-black
+            root: "training/"
+            glob: "*.py"
+            run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:24.4.2 black {staged_files}
+            stage_fixed: true
+          - name: backend-goimports
+            root: "backend/"
+            glob: "*.go"
+            run: docker run --rm --entrypoint goimports -v "$PWD:/app" -w /app cytopia/goimports:latest -w {staged_files}
+            stage_fixed: true
+          - name: frontend-prettier
+            root: "frontend/"
+            glob: "*.{ts,tsx,js,jsx,css,html}"
+            run: docker run --rm -v "$PWD:/workdir" -w /workdir tmknom/prettier:3.2.5 --write {staged_files}
+            stage_fixed: true
+          - name: docs-mkdocs
+            root: "docs/"
+            glob: "*.{md,markdown}"
+            run: docker run --rm -v "$PWD:/workdir" -w /workdir davidanson/markdownlint-cli2:v0.13.0 --fix {staged_files}
+            exclude:
+              - "docs/adr/_template.md"
+            stage_fixed: true
 
-    # Python: Training
-    training-black:
-      priority: 1
-      root: "training/"
-      glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:24.4.2 black {staged_files}
-      stage_fixed: true
-    training-flake8:
-      priority: 2
-      root: "training/"
-      glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:7.0.0 {staged_files}
-    training-mypy:
-      priority: 2
-      root: "training/"
-      glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q poetry && poetry install && poetry run mypy {staged_files}"
-    training-test:
-      priority: 3
-      root: "training/"
-      glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q poetry && poetry install && poetry run pytest -v"
-
-    # Go: Backend
-    backend-goimports:
-      priority: 1
-      root: "backend/"
-      glob: "*.go"
-      run: docker run --rm --entrypoint goimports -v "$PWD:/app" -w /app cytopia/goimports:latest -w {staged_files}
-      stage_fixed: true
-    backend-golangci-lint:
-      priority: 2
-      root: "backend/"
-      glob: "*.go"
-      run: docker run --rm -v "$PWD:/app" -w /app golangci/golangci-lint:v2.12.2 bash -c "go mod download && golangci-lint run ./..."
-    backend-test:
-      priority: 3
-      root: "backend/"
-      glob: "*.go"
-      run: docker run --rm -v "$PWD:/app" -w /app golang:1.26 bash -c "go mod download && go test -v ./..."
-
-    # TypeScript/React: Frontend
-    frontend-prettier:
-      priority: 1
-      root: "frontend/"
-      glob: "*.{ts,tsx,js,jsx,css,html}"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir tmknom/prettier:3.2.5 --write {staged_files}
-      stage_fixed: true
-    frontend-eslint:
-      priority: 2
-      root: "frontend/"
-      glob: "*.{ts,tsx,js,jsx}"
-      run: docker run --rm -v "$PWD:/workdir" -v frontend-node-modules:/workdir/node_modules -w /workdir node:22-alpine sh -c "test -d node_modules/eslint || npm install --no-audit --no-fund > /dev/null 2>&1; npx eslint {staged_files}"
-    frontend-tsc:
-      priority: 2
-      root: "frontend/"
-      glob: "*.{ts,tsx}"
-      run: docker run --rm -v "$PWD:/workdir" -v frontend-node-modules:/workdir/node_modules -w /workdir node:22-alpine sh -c "test -d node_modules/typescript || npm install --no-audit --no-fund > /dev/null 2>&1; npx tsc --noEmit"
-
-    # MkDocs: Documentation
-    docs-mkdocs:
-      priority: 1
-      root: "docs/"
-      glob: "*.{md,markdown}"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir davidanson/markdownlint-cli2:v0.13.0 --fix {staged_files}
-      exclude:
-        - "docs/adr/_template.md"
-      stage_fixed: true
+    # --- GROUP 2: LINTERS & TESTS ---
+    - name: verification
+      group:
+        parallel: true
+        jobs:
+        # LINTERS
+          - name: inference-flake8
+            root: "inference/"
+            glob: "*.py"
+            run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:7.0.0 {staged_files}
+          - name: inference-mypy
+            root: "inference/"
+            glob: "*.py"
+            run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q poetry && poetry install && poetry run mypy {staged_files}"
+          - name: training-flake8
+            root: "training/"
+            glob: "*.py"
+            run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:7.0.0 {staged_files}
+          - name: training-mypy
+            root: "training/"
+            glob: "*.py"
+            run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q poetry && poetry install && poetry run mypy {staged_files}"
+          - name: backend-golangci-lint
+            root: "backend/"
+            glob: "*.go"
+            run: docker run --rm -v "$PWD:/app" -w /app golangci/golangci-lint:v2.12.2 bash -c "go mod download && golangci-lint run ./..."
+          - name: frontend-eslint
+            root: "frontend/"
+            glob: "*.{ts,tsx,js,jsx}"
+            run: docker run --rm -v "$PWD:/workdir" -v frontend-node-modules:/workdir/node_modules -w /workdir node:22-alpine sh -c "test -d node_modules/eslint || npm install --no-audit --no-fund > /dev/null 2>&1; npx eslint {staged_files}"
+          - name: frontend-tsc
+            root: "frontend/"
+            glob: "*.{ts,tsx}"
+            run: docker run --rm -v "$PWD:/workdir" -v frontend-node-modules:/workdir/node_modules -w /workdir node:22-alpine sh -c "test -d node_modules/typescript || npm install --no-audit --no-fund > /dev/null 2>&1; npx tsc --noEmit"
+        # TESTS
+          - name: training-test
+            root: "training/"
+            glob: "*.py"
+            run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q poetry && poetry install && poetry run pytest -v"
+          - name: backend-test
+            root: "backend/"
+            glob: "*.go"
+            run: docker run --rm -v "$PWD:/app" -w /app golang:1.26 bash -c "go mod download && go test -v ./..."

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -6,84 +6,84 @@ pre-commit:
       priority: 1
       root: "inference/"
       glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:latest_release black {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:24.4.2 black {staged_files}
       stage_fixed: true
     inference-flake8:
       priority: 2
       root: "inference/"
       glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:latest {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:7.0.0 {staged_files}
     inference-mypy:
       priority: 2
       root: "inference/"
       glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir cytopia/mypy:latest {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q mypy && mypy --ignore-missing-imports --disable-error-code no-untyped-def {staged_files}"
 
     # Python: Training
     training-black:
       priority: 1
       root: "training/"
       glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:latest_release black {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:24.4.2 black {staged_files}
       stage_fixed: true
     training-flake8:
       priority: 2
       root: "training/"
       glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:latest {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:7.0.0 {staged_files}
     training-mypy:
       priority: 2
       root: "training/"
       glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir cytopia/mypy:latest {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q mypy && mypy --ignore-missing-imports {staged_files}"
     training-test:
       priority: 3
       root: "training/"
       glob: "*.py"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.11-slim bash -c "pip install -q pytest && pytest -v"
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.12-slim bash -c "pip install -q poetry && poetry install --no-interaction --no-ansi --no-root -q && poetry run pytest -v"
 
     # Go: Backend
     backend-goimports:
       priority: 1
       root: "backend/"
       glob: "*.go"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir cytopia/goimports:latest -w {staged_files}
+      run: docker run --rm --entrypoint goimports -v "$PWD:/app" -w /app cytopia/goimports:latest -w {staged_files}
       stage_fixed: true
     backend-golangci-lint:
       priority: 2
       root: "backend/"
       glob: "*.go"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir golangci/golangci-lint:latest golangci-lint run ./...
+      run: docker run --rm -v "$PWD:/app" -w /app golangci/golangci-lint:v2.12.2 bash -c "go mod download && golangci-lint run --disable errcheck ./..."
     backend-test:
       priority: 3
       root: "backend/"
       glob: "*.go"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir golang:alpine go test -v ./...
+      run: docker run --rm -v "$PWD:/app" -w /app golang:1.26 bash -c "go mod download && go test -v ./..."
 
     # TypeScript/React: Frontend
     frontend-prettier:
       priority: 1
       root: "frontend/"
       glob: "*.{ts,tsx,js,jsx,css,html}"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir tmknom/prettier:latest --write {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir tmknom/prettier:3.2.5 --write {staged_files}
       stage_fixed: true
     frontend-eslint:
       priority: 2
       root: "frontend/"
       glob: "*.{ts,tsx,js,jsx}"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir node:alpine npx --yes eslint {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -v frontend-node-modules:/workdir/node_modules -w /workdir node:22-alpine sh -c "test -d node_modules/eslint || npm install --no-audit --no-fund > /dev/null 2>&1; npx eslint {staged_files}"
     frontend-tsc:
       priority: 2
       root: "frontend/"
       glob: "*.{ts,tsx}"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir node:alpine npx --yes typescript tsc --noEmit
+      run: docker run --rm -v "$PWD:/workdir" -v frontend-node-modules:/workdir/node_modules -w /workdir node:22-alpine sh -c "test -d node_modules/typescript || npm install --no-audit --no-fund > /dev/null 2>&1; npx tsc --noEmit"
 
     # MkDocs: Documentation
     docs-mkdocs:
       priority: 1
       root: "docs/"
       glob: "*.{md,markdown}"
-      run: docker run --rm -v "$PWD:/workdir" -w /workdir davidanson/markdownlint-cli2:latest --fix {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir davidanson/markdownlint-cli2:v0.13.0 --fix {staged_files}
       exclude:
         - "docs/adr/_template.md"
       stage_fixed: true

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -6,77 +6,77 @@ pre-commit:
       priority: 1
       root: "inference/"
       glob: "*.py"
-      run: poetry run black {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:latest_release black {staged_files}
       stage_fixed: true
     inference-flake8:
       priority: 2
       root: "inference/"
       glob: "*.py"
-      run: poetry run flake8 {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:latest {staged_files}
     inference-mypy:
       priority: 2
       root: "inference/"
       glob: "*.py"
-      run: poetry run mypy {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir cytopia/mypy:latest {staged_files}
 
     # Python: Training
     training-black:
       priority: 1
       root: "training/"
       glob: "*.py"
-      run: poetry run black {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir pyfound/black:latest_release black {staged_files}
       stage_fixed: true
     training-flake8:
       priority: 2
       root: "training/"
       glob: "*.py"
-      run: poetry run flake8 {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir alpine/flake8:latest {staged_files}
     training-mypy:
       priority: 2
       root: "training/"
       glob: "*.py"
-      run: poetry run mypy {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir cytopia/mypy:latest {staged_files}
     training-test:
       priority: 3
       root: "training/"
       glob: "*.py"
-      run: poetry run pytest -v
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir python:3.11-slim bash -c "pip install -q pytest && pytest -v"
 
     # Go: Backend
     backend-goimports:
       priority: 1
       root: "backend/"
       glob: "*.go"
-      run: go run golang.org/x/tools/cmd/goimports@latest -w {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir cytopia/goimports:latest -w {staged_files}
       stage_fixed: true
     backend-golangci-lint:
       priority: 2
       root: "backend/"
       glob: "*.go"
-      run: go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run ./...
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir golangci/golangci-lint:latest golangci-lint run ./...
     backend-test:
       priority: 3
       root: "backend/"
       glob: "*.go"
-      run: go test -v ./...
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir golang:alpine go test -v ./...
 
     # TypeScript/React: Frontend
     frontend-prettier:
       priority: 1
       root: "frontend/"
       glob: "*.{ts,tsx,js,jsx,css,html}"
-      run: npx prettier --write {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir tmknom/prettier:latest --write {staged_files}
       stage_fixed: true
     frontend-eslint:
       priority: 2
       root: "frontend/"
       glob: "*.{ts,tsx,js,jsx}"
-      run: npx eslint {staged_files}
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir node:alpine npx --yes eslint {staged_files}
     frontend-tsc:
       priority: 2
       root: "frontend/"
       glob: "*.{ts,tsx}"
-      run: npx tsc --noEmit
+      run: docker run --rm -v "$PWD:/workdir" -w /workdir node:alpine npx --yes typescript tsc --noEmit
 
     # MkDocs: Documentation
     docs-mkdocs:


### PR DESCRIPTION
### Description
This PR migrates our local Lefthook setup to use Docker containers for all pre-commit checks. This ensures a uniform CI environment across the team and removes the need to install linters or language environments directly on the host machine.

### Key Changes
* Rewrote `lefthook.yaml` to run all commands (Black, Flake8, Mypy, Prettier, ESLint, golangci-lint, pytest, go test) inside lightweight Docker containers (`alpine`, `slim`).
* Bound local directories to containers via Docker volumes for execution speed.
* Updated `Makefile` `proto` target. It now automatically generates required `__init__.py` files for protobuf stubs inside the `inference` module to prevent `mypy` resolution failures.

Closes #68