### PR TITLE
feat(devops): implement path-filtered remote CI and resolve linter conflicts

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,186 @@
+name: PR Conditional Quality Checks
+
+on:
+  pull_request:
+    branches: [ develop, main ]
+
+jobs:
+  # JOB 1: Detect which files were modified in the Pull Request
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      inference: ${{ steps.filter.outputs.inference }}
+      training: ${{ steps.filter.outputs.training }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+
+      - name: Categorize changed files by module paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+            inference:
+              - 'inference/**'
+            training:
+              - 'training/**'
+            frontend:
+              - 'frontend/**'
+            docs:
+              - 'docs/**'
+
+  # JOB 2: Run Backend checks if files in backend/ changed
+  backend-tests:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.backend == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.2'
+          cache-dependency-path: backend/go.sum
+
+      # Install buf CLI used by the project's Makefile
+      - name: Setup Buf
+        uses: bufbuild/buf-setup-action@v1
+
+      - name: Generate Protobuf stubs and modern init files
+        run: make proto
+
+      - name: Run Golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.57.2
+          working-directory: backend
+
+      - name: Execute Backend Unit Tests
+        run: |
+          cd backend
+          go test -v ./...
+
+  # JOB 3: Run Inference checks if files in inference/ changed
+  inference-tests:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.inference == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Python environment
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.9'
+
+      # Install buf CLI used by the project's Makefile
+      - name: Setup Buf
+        uses: bufbuild/buf-setup-action@v1
+
+      - name: Generate Protobuf stubs and modern init files
+        run: make proto
+
+      - name: Install Python quality tools & dependencies
+        run: |
+          pip install black flake8 mypy
+          if [ -f inference/requirements.txt ]; then pip install -r inference/requirements.txt; fi
+
+      - name: Run Black formatter check
+        run: black --check inference/
+
+      - name: Run Flake8 linter
+        run: flake8 inference/
+
+      - name: Run Mypy static type checker
+        run: mypy --ignore-missing-imports inference/
+
+  # JOB 4: Run Training checks if files in training/ changed
+  training-tests:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.training == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Python environment
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.9'
+
+      - name: Install Python quality tools & dependencies
+        run: |
+          pip install black flake8 mypy pytest
+          if [ -f training/requirements.txt ]; then pip install -r training/requirements.txt; fi
+
+      - name: Run Black formatter check
+        run: black --check training/
+
+      - name: Run Flake8 linter
+        run: flake8 training/
+
+      - name: Run Mypy static type checker
+        run: mypy --ignore-missing-imports training/
+
+      - name: Execute Training Module Tests
+        run: |
+          cd training
+          pytest -v
+
+  # JOB 5: Run Frontend checks if files in frontend/ changed
+  frontend-tests:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.frontend == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install node dependencies
+        run: |
+          cd frontend
+          npm ci
+
+      - name: Run Prettier formatting check
+        run: |
+          cd frontend
+          npx prettier --check "src/**/*.{ts,tsx,js,jsx,css,html}"
+
+      - name: Run ESLint check
+        run: |
+          cd frontend
+          npx eslint .
+
+      - name: Run TypeScript compilation check
+        run: |
+          cd frontend
+          npx tsc --noEmit
+
+  # JOB 6: Run Documentation checks if files in docs/ changed
+  docs-tests:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.docs == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+
+      - name: Run Markdownlint check against modified documentation
+        uses: davidanson/markdownlint-cli2-action@v1
+        with:
+          globs: 'docs/**/*.{md,markdown}'

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,7 +2,7 @@ name: PR Conditional Quality Checks
 
 on:
   pull_request:
-    branches: [ develop, main ]
+    branches: [ development, main ]
 
 jobs:
   detect-changes:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,7 +5,6 @@ on:
     branches: [ develop, main ]
 
 jobs:
-  # JOB 1: Detect which files were modified in the Pull Request
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
@@ -34,7 +33,6 @@ jobs:
             docs:
               - 'docs/**'
 
-  # JOB 2: Run Backend checks if files in backend/ changed
   backend-tests:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.backend == 'true' }}
@@ -49,7 +47,6 @@ jobs:
           go-version: '1.22.2'
           cache-dependency-path: backend/go.sum
 
-      # Install buf CLI used by the project's Makefile
       - name: Setup Buf
         uses: bufbuild/buf-setup-action@v1
 
@@ -67,7 +64,6 @@ jobs:
           cd backend
           go test -v ./...
 
-  # JOB 3: Run Inference checks if files in inference/ changed
   inference-tests:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.inference == 'true' }}
@@ -81,7 +77,6 @@ jobs:
         with:
           python-version: '3.11.9'
 
-      # Install buf CLI used by the project's Makefile
       - name: Setup Buf
         uses: bufbuild/buf-setup-action@v1
 
@@ -96,13 +91,13 @@ jobs:
       - name: Run Black formatter check
         run: black --check inference/
 
+      # Zmiana: wymuszamy limit 88 znaków i ignorujemy folder z plikami wygenerowanymi przez protobuf
       - name: Run Flake8 linter
-        run: flake8 inference/
+        run: flake8 inference/ --max-line-length=88 --extend-exclude=inference/src/inference/pb/
 
       - name: Run Mypy static type checker
         run: mypy --ignore-missing-imports inference/
 
-  # JOB 4: Run Training checks if files in training/ changed
   training-tests:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.training == 'true' }}
@@ -124,8 +119,9 @@ jobs:
       - name: Run Black formatter check
         run: black --check training/
 
+      # Zmiana: wymuszamy limit 88 znaków, żeby zsynchronizować z Blackiem
       - name: Run Flake8 linter
-        run: flake8 training/
+        run: flake8 training/ --max-line-length=88
 
       - name: Run Mypy static type checker
         run: mypy --ignore-missing-imports training/
@@ -135,7 +131,6 @@ jobs:
           cd training
           pytest -v
 
-  # JOB 5: Run Frontend checks if files in frontend/ changed
   frontend-tests:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.frontend == 'true' }}
@@ -171,7 +166,6 @@ jobs:
           cd frontend
           npx tsc --noEmit
 
-  # JOB 6: Run Documentation checks if files in docs/ changed
   docs-tests:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.docs == 'true' }}
@@ -180,7 +174,10 @@ jobs:
       - name: Checkout repository code
         uses: actions/checkout@v4
 
+      # Zmiana: dodano exclude dla szablonu ADR
       - name: Run Markdownlint check against modified documentation
         uses: davidanson/markdownlint-cli2-action@v1
         with:
-          globs: 'docs/**/*.{md,markdown}'
+          globs: |
+            docs/**/*.{md,markdown}
+            !docs/adr/_template.md

--- a/docs/adr/remote-enforced-ci.md
+++ b/docs/adr/remote-enforced-ci.md
@@ -1,0 +1,20 @@
+# ADR: Remote-Enforced CI with Path-Filtering
+
+## Status
+
+Accepted
+
+## Context
+
+Currently, verifying Pull Requests requires reviewers to either trust the author's word that tests pass, or manually check out the branch and run tests locally. This local testing approach is time-consuming, prone to environment mismatches ("it works on my machine"), and disrupts the reviewer's workflow. We needed to evaluate the best approach between a completely remote-enforced CI and local testing. Furthermore, running the entire monolith test suite for every minor change is inefficient and wastes CI compute resources.
+
+## Decision
+
+We decided to shift from local-only testing to a completely remote-enforced CI pipeline using GitHub Actions. To optimize execution time and resource usage, we integrated the `dorny/paths-filter` action. This allows the CI to dynamically trigger specific test jobs (e.g., backend, frontend, inference, training) based exclusively on the paths of the modified files in a Pull Request. Local hooks (Lefthook) remain available for pre-commit checks, but GitHub Actions is now the ultimate source of truth.
+
+## Consequences
+
+* **Positive:** Reviewers can instantly see test results directly on the GitHub PR page without any local setup.
+* **Positive:** CI compute costs and feedback loop times are minimized by only running relevant tests.
+* **Positive:** Establishes a strict, automated quality gate before any code is merged.
+* **Negative:** CI workflow files (`.github/workflows/`) will require occasional maintenance as the project structure evolves.

--- a/docs/adr/remote-enforced-ci.md
+++ b/docs/adr/remote-enforced-ci.md
@@ -1,20 +1,34 @@
-# ADR: Remote-Enforced CI with Path-Filtering
+# ADR: Remote-Enforced CI with Path-Filtering (Temporary Solution)
 
 ## Status
 
-Accepted
+Accepted (Temporary)
 
 ## Context
 
-Currently, verifying Pull Requests requires reviewers to either trust the author's word that tests pass, or manually check out the branch and run tests locally. This local testing approach is time-consuming, prone to environment mismatches ("it works on my machine"), and disrupts the reviewer's workflow. We needed to evaluate the best approach between a completely remote-enforced CI and local testing. Furthermore, running the entire monolith test suite for every minor change is inefficient and wastes CI compute resources.
+Currently, verifying Pull Requests requires reviewers to either trust the author's word that tests pass, or manually check out the branch and run tests locally. We needed to evaluate the best approach between a completely remote-enforced CI and local testing.
+
+While setting up GitHub Actions with `dorny/paths-filter` solves the immediate problem of remote verification and compute efficiency, it introduces two structural issues:
+
+1. **Configuration Drift:** Having separate configurations for local pre-commits (`lefthook.yaml`) and remote CI (`.github/workflows/pr-tests.yml`) means versions and rules can easily fall out of sync.
+2. **Missing Integration Tests:** The current setup only triggers unit tests and linters, leaving integration tests out of the automated pipeline.
 
 ## Decision
 
-We decided to shift from local-only testing to a completely remote-enforced CI pipeline using GitHub Actions. To optimize execution time and resource usage, we integrated the `dorny/paths-filter` action. This allows the CI to dynamically trigger specific test jobs (e.g., backend, frontend, inference, training) based exclusively on the paths of the modified files in a Pull Request. Local hooks (Lefthook) remain available for pre-commit checks, but GitHub Actions is now the ultimate source of truth.
+We decided to implement the GitHub Actions path-filtering workflow as an **acceptable, temporary step forward**. It is significantly better than having no remote CI at all.
+
+However, to address configuration drift, we establish that this is not the final state. We will research and transition to a Single Source of Truth (SSoT) architecture for all CI checks.
+
+## Future Exploration (SSoT)
+
+To achieve a Single Source of Truth and include integration tests, we will explore:
+
+* Executing `lefthook run` directly within the GitHub Actions runners to unify local and remote checks under one configuration file.
+* Utilizing containerized CI/CD tools (e.g., Earthly, Dagger) to guarantee identical pipeline execution locally and remotely.
+* Expanding the pipeline to provision necessary databases/services for full integration testing.
 
 ## Consequences
 
-* **Positive:** Reviewers can instantly see test results directly on the GitHub PR page without any local setup.
-* **Positive:** CI compute costs and feedback loop times are minimized by only running relevant tests.
-* **Positive:** Establishes a strict, automated quality gate before any code is merged.
-* **Negative:** CI workflow files (`.github/workflows/`) will require occasional maintenance as the project structure evolves.
+* **Positive:** Immediate, drastic improvement in PR verification and reviewer experience.
+* **Positive:** Minimized CI compute costs and feedback loop times.
+* **Negative (Technical Debt):** Temporary configuration drift exists between Lefthook and GitHub Actions until the SSoT solution is researched and implemented.


### PR DESCRIPTION
### Description
This PR introduces remote-enforced CI checks via GitHub Actions. Tests now trigger automatically based on the files modified in the PR, saving CI compute time and developer local setup effort. Added an ADR explaining the decision.

**Recent fixes for CI environments:**
* Adjusted `flake8` to use an 88-character line limit to synchronize with `black` formatter.
* Excluded Protobuf-generated files (`*_pb2.py` and `*_pb2_grpc.py`) from Python linting.
* Excluded the ADR template (`docs/adr/_template.md`) from `markdownlint-cli2`.

Closes #69