### PR TITLE
fix(ci): resolve missing dependencies in training module using Poetry

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -75,13 +75,14 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11.9'
+          python-version: '3.11'
 
       - name: Setup Buf
         uses: bufbuild/buf-setup-action@v1
 
       - name: Generate Protobuf stubs and modern init files
         run: make proto
+
 
       - name: Install Python quality tools & dependencies
         run: |
@@ -91,7 +92,6 @@ jobs:
       - name: Run Black formatter check
         run: black --check inference/
 
-      # Zmiana: wymuszamy limit 88 znaków i ignorujemy folder z plikami wygenerowanymi przez protobuf
       - name: Run Flake8 linter
         run: flake8 inference/ --max-line-length=88 --extend-exclude=inference/src/inference/pb/
 
@@ -109,27 +109,35 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11.9'
+          python-version: '3.11'
 
-      - name: Install Python quality tools & dependencies
+
+      - name: Install Poetry and base tools
+        run: pip install poetry black flake8 mypy
+
+
+      - name: Install ML dependencies via Poetry
         run: |
-          pip install black flake8 mypy pytest
-          if [ -f training/requirements.txt ]; then pip install -r training/requirements.txt; fi
+          cd training
+          poetry install
 
       - name: Run Black formatter check
         run: black --check training/
 
-      # Zmiana: wymuszamy limit 88 znaków, żeby zsynchronizować z Blackiem
       - name: Run Flake8 linter
         run: flake8 training/ --max-line-length=88
 
+
       - name: Run Mypy static type checker
-        run: mypy --ignore-missing-imports training/
+        run: |
+          cd training
+          poetry run mypy --ignore-missing-imports .
+
 
       - name: Execute Training Module Tests
         run: |
           cd training
-          pytest -v
+          poetry run pytest -v
 
   frontend-tests:
     needs: detect-changes
@@ -174,7 +182,6 @@ jobs:
       - name: Checkout repository code
         uses: actions/checkout@v4
 
-      # Zmiana: dodano exclude dla szablonu ADR
       - name: Run Markdownlint check against modified documentation
         uses: davidanson/markdownlint-cli2-action@v1
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -75,14 +75,13 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Setup Buf
         uses: bufbuild/buf-setup-action@v1
 
       - name: Generate Protobuf stubs and modern init files
         run: make proto
-
 
       - name: Install Python quality tools & dependencies
         run: |
@@ -106,20 +105,37 @@ jobs:
       - name: Checkout repository code
         uses: actions/checkout@v4
 
-      - name: Set up Python environment
+      - name: Set up Python 3.12
+        id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
+      # Wdrażamy oficjalną akcję z Marketplace'u
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
 
-      - name: Install Poetry and base tools
-        run: pip install poetry black flake8 mypy
+      # Sprawdzamy, czy mamy już zapisane środowisko z poprzedniego uruchomienia
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: training/.venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('training/poetry.lock') }}
 
-
-      - name: Install ML dependencies via Poetry
+      # Instalujemy zależności ML tylko wtedy, gdy NIE znaleziono cache'u
+      - name: Install dependencies via Poetry
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: |
           cd training
-          poetry install
+          poetry install --no-interaction
+
+      # Instalujemy lintery (na wypadek gdyby ML-owcy nie mieli ich w poetry.lock)
+      - name: Install base linters
+        run: pip install black flake8 mypy
 
       - name: Run Black formatter check
         run: black --check training/
@@ -127,12 +143,10 @@ jobs:
       - name: Run Flake8 linter
         run: flake8 training/ --max-line-length=88
 
-
       - name: Run Mypy static type checker
         run: |
           cd training
           poetry run mypy --ignore-missing-imports .
-
 
       - name: Execute Training Module Tests
         run: |


### PR DESCRIPTION
### Description
The `training-tests` CI job was failing with `ModuleNotFoundError: No module named 'pandas'` because the GitHub Actions runner was using a bare Python environment. This PR implements Poetry to properly manage and install the ML team's dependencies.

### Changes
* Added `poetry` installation to the `training-tests` workflow.
* Replaced standard `pip` fallbacks with `poetry install` for the training module.
* Wrapped `mypy` and `pytest` executions in `poetry run` to ensure they run within the correctly populated virtual environment.